### PR TITLE
Fix orphan Generic instance for Value for aeson >= 1.2.1.0

### DIFF
--- a/Data/Aeson/AutoType/Pretty.hs
+++ b/Data/Aeson/AutoType/Pretty.hs
@@ -3,7 +3,11 @@
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE StandaloneDeriving  #-}
 {-# LANGUAGE ViewPatterns        #-}
+{-# LANGUAGE CPP                 #-}
+#if MIN_VERSION_aeson(1,2,1)
+#else
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+#endif
 
 -- | Instances of @Text.PrettyPrint.Out@ class to visualize
 -- Aeson @Value@ data structure. 
@@ -33,7 +37,10 @@ instance (Out a) => Out (Vector a) where
   doc (V.toList -> v) = "<" <+> doc v <+> ">"
   docPrec _ = doc
 
+#if MIN_VERSION_aeson(1,2,1)
+#else
 deriving instance Generic Value
+#endif
 
 instance Out Value
 

--- a/json-autotype.cabal
+++ b/json-autotype.cabal
@@ -62,7 +62,7 @@ library
                        Data.Aeson.AutoType.Util
   build-depends:       base                 >=4.3  && <4.10,
                        GenericPretty        >=1.2  && <1.3,
-                       aeson                >=0.7  && <0.13,
+                       aeson                >=0.7  && <1.3,
                        bytestring           >=0.9  && <0.11,
                        containers           >=0.3  && <0.6,
                        filepath             >=1.3  && <1.5,


### PR DESCRIPTION
Doesn't compile as aeson 1.2.1.0 introduces a Generic instance for Value, meaning the orphan defined here conflicts.

CPP should make it backwards compatible.