### PR TITLE
Update for Stack LTS 21.9 and Aeson 2.x

### DIFF
--- a/json-alt/json-alt.cabal
+++ b/json-alt/json-alt.cabal
@@ -1,12 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
---
 
 name:                json-alt
-version:             1.0.1
+version:             1.0.0
 synopsis:            Union 'alternative' or Either that has untagged JSON encoding.
 description:         Parsing JSON with Aeson often requires decoding fields
                      that have more than one Haskell type.
@@ -64,6 +63,6 @@ library
       DeriveGeneric
       RecordWildCards
   build-depends:
-      aeson >=1.2.1 && <1.6
-    , base >=4.3 && <5
+      aeson
+    , base >=4.0.0 && <=5.0
   default-language: Haskell2010

--- a/json-alt/package.yaml
+++ b/json-alt/package.yaml
@@ -60,8 +60,8 @@ other-extensions:
 - DeriveGeneric
 - RecordWildCards
 dependencies:
-- base >=4.3 && <5
-- aeson >=1.2.1 && <1.6
+- base >= 4.0.0 && <= 5.0
+- aeson
 library:
   exposed-modules:
   - Data.Aeson.AutoType.Alternative

--- a/json-autotype/app/GenerateJSONParser.hs
+++ b/json-autotype/app/GenerateJSONParser.hs
@@ -32,6 +32,7 @@ import           Data.Aeson.AutoType.Format
 import           Data.Aeson.AutoType.Split
 import           Data.Aeson.AutoType.Type
 import           Data.Aeson.AutoType.Util
+import           Data.Aeson.AutoType.Pretty
 import qualified Data.Yaml as Yaml
 
 import           Options.Applicative

--- a/json-autotype/json-autotype.cabal
+++ b/json-autotype/json-autotype.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
 name:                json-autotype
-version:             3.1.3
+version:             3.1.2
 synopsis:            Automatic type declaration for JSON input data
 description:         Generates datatype declarations with Aeson''s ''Data.Aeson.FromJSON''
                      .
@@ -87,12 +87,12 @@ library
       Data.Aeson.AutoType.CodeGen.Generic
       Data.Aeson.AutoType.CodeGen.Elm
       Data.Aeson.AutoType.CodeGen.ElmFormat
-      Data.Aeson.AutoType.Pretty
       Data.Aeson.AutoType.Split
       Data.Aeson.AutoType.Type
       Data.Aeson.AutoType.Test
       Data.Aeson.AutoType.Util
       Data.Aeson.AutoType.Nested
+      Data.Aeson.AutoType.Pretty
   other-modules:
       Data.Aeson.AutoType.CodeGen.Common
       Data.Aeson.AutoType.Plugin.Subtype
@@ -109,27 +109,27 @@ library
       DeriveGeneric
       RecordWildCards
   build-depends:
-      GenericPretty ==1.2.*
-    , QuickCheck >=2.4 && <3.0
-    , aeson >=1.2.1 && <1.6
-    , base >=4.9 && <5
-    , containers >=0.3 && <0.7
-    , data-default ==0.7.*
-    , filepath >=1.3 && <1.5
-    , hashable >=1.2 && <1.4
+      GenericPretty
+    , QuickCheck
+    , aeson
+    , base >=4.0.0 && <5.0
+    , containers
+    , data-default
+    , filepath
+    , hashable
     , json-alt
-    , lens >=4.1 && <4.20
-    , mtl >=2.1 && <2.3
-    , pretty >=1.1 && <1.3
-    , process >=1.1 && <1.7
+    , lens
+    , mtl
+    , pretty
+    , process
     , run-haskell-module
-    , scientific >=0.3 && <0.5
-    , smallcheck >=1.0 && <1.2
+    , scientific
+    , smallcheck
     , template-haskell
-    , text >=1.1 && <1.4
-    , uniplate ==1.6.*
-    , unordered-containers ==0.2.*
-    , vector >=0.9 && <0.13
+    , text
+    , uniplate
+    , unordered-containers
+    , vector
   default-language: Haskell2010
 
 executable json-autotype
@@ -150,27 +150,27 @@ executable json-autotype
       DeriveGeneric
       RecordWildCards
   build-depends:
-      GenericPretty ==1.2.*
-    , aeson >=1.2.1 && <1.6
-    , base >=4.9 && <5
-    , bytestring >=0.9 && <0.11
-    , containers >=0.3 && <0.7
-    , filepath >=1.3 && <1.5
-    , hashable >=1.2 && <1.4
+      GenericPretty
+    , aeson
+    , base >=4.0.0 && <5.0
+    , bytestring
+    , containers
+    , filepath
+    , hashable
     , json-alt
     , json-autotype
-    , lens >=4.1 && <4.20
-    , mtl >=2.1 && <2.3
-    , optparse-applicative >=0.12 && <1.0
-    , pretty >=1.1 && <1.3
-    , process >=1.1 && <1.7
-    , scientific >=0.3 && <0.5
+    , lens
+    , mtl
+    , optparse-applicative
+    , pretty
+    , process
+    , scientific
     , template-haskell
-    , text >=1.1 && <1.4
-    , uniplate ==1.6.*
-    , unordered-containers ==0.2.*
-    , vector >=0.9 && <0.13
-    , yaml >=0.8 && <0.12
+    , text
+    , uniplate
+    , unordered-containers
+    , vector
+    , yaml
   default-language: Haskell2010
 
 test-suite json-autotype-examples
@@ -192,28 +192,28 @@ test-suite json-autotype-examples
       DeriveGeneric
       RecordWildCards
   build-depends:
-      GenericPretty ==1.2.*
-    , QuickCheck >=2.4 && <3.0
-    , aeson >=1.2.1 && <1.6
-    , base >=4.9 && <5
-    , containers >=0.3 && <0.7
-    , directory >=1.1 && <1.4
-    , filepath >=1.3 && <1.5
-    , hashable >=1.2 && <1.4
+      GenericPretty
+    , QuickCheck
+    , aeson
+    , base >=4.0.0 && <5.0
+    , containers
+    , directory
+    , filepath
+    , hashable
     , json-alt
     , json-autotype
-    , lens >=4.1 && <4.20
-    , mtl >=2.1 && <2.3
-    , optparse-applicative >=0.11 && <1.0
-    , pretty >=1.1 && <1.3
-    , process >=1.1 && <1.7
-    , scientific >=0.3 && <0.5
-    , smallcheck >=1.0 && <1.2
+    , lens
+    , mtl
+    , optparse-applicative
+    , pretty
+    , process
+    , scientific
+    , smallcheck
     , template-haskell
-    , text >=1.1 && <1.4
-    , uniplate ==1.6.*
-    , unordered-containers ==0.2.*
-    , vector >=0.9 && <0.13
+    , text
+    , uniplate
+    , unordered-containers
+    , vector
   default-language: Haskell2010
 
 test-suite json-autotype-gen-test
@@ -235,29 +235,29 @@ test-suite json-autotype-gen-test
       DeriveGeneric
       RecordWildCards
   build-depends:
-      GenericPretty ==1.2.*
-    , QuickCheck >=2.4 && <3.0
-    , aeson >=1.2.1 && <1.6
-    , base >=4.9 && <5
-    , bytestring >=0.9 && <0.11
-    , containers >=0.3 && <0.7
-    , directory >=1.1 && <1.4
-    , filepath >=1.3 && <1.5
-    , hashable >=1.2 && <1.4
+      GenericPretty
+    , QuickCheck
+    , aeson
+    , base >=4.0.0 && <5.0
+    , bytestring
+    , containers
+    , directory
+    , filepath
+    , hashable
     , json-alt
     , json-autotype
-    , lens >=4.1 && <4.20
-    , mtl >=2.1 && <2.3
-    , optparse-applicative >=0.12 && <1.0
-    , pretty >=1.1 && <1.3
-    , process >=1.1 && <1.7
-    , scientific >=0.3 && <0.5
-    , smallcheck >=1.0 && <1.2
+    , lens
+    , mtl
+    , optparse-applicative
+    , pretty
+    , process
+    , scientific
+    , smallcheck
     , template-haskell
-    , text >=1.1 && <1.4
-    , uniplate ==1.6.*
-    , unordered-containers ==0.2.*
-    , vector >=0.9 && <0.13
+    , text
+    , uniplate
+    , unordered-containers
+    , vector
   default-language: Haskell2010
 
 test-suite json-autotype-qc-test
@@ -279,25 +279,25 @@ test-suite json-autotype-qc-test
       DeriveGeneric
       RecordWildCards
   build-depends:
-      GenericPretty ==1.2.*
-    , QuickCheck >=2.4 && <3.0
-    , aeson >=1.2.1 && <1.6
-    , base >=4.9 && <5
-    , containers >=0.3 && <0.7
-    , filepath >=1.3 && <1.5
-    , hashable >=1.2 && <1.4
+      GenericPretty
+    , QuickCheck
+    , aeson
+    , base >=4.0.0 && <5.0
+    , containers
+    , filepath
+    , hashable
     , json-alt
     , json-autotype
-    , lens >=4.1 && <4.20
-    , mtl >=2.1 && <2.3
-    , optparse-applicative >=0.12 && <1.0
-    , pretty >=1.1 && <1.3
-    , process >=1.1 && <1.7
-    , scientific >=0.3 && <0.5
-    , smallcheck >=1.0 && <1.2
+    , lens
+    , mtl
+    , optparse-applicative
+    , pretty
+    , process
+    , scientific
+    , smallcheck
     , template-haskell
-    , text >=1.1 && <1.4
-    , uniplate ==1.6.*
-    , unordered-containers ==0.2.*
-    , vector >=0.9 && <0.13
+    , text
+    , uniplate
+    , unordered-containers
+    , vector
   default-language: Haskell2010

--- a/json-autotype/package.yaml
+++ b/json-autotype/package.yaml
@@ -73,21 +73,21 @@ other-extensions:
 - DeriveGeneric
 - RecordWildCards
 dependencies:
-- base >=4.9 && <5
-- GenericPretty >=1.2 && <1.3
-- aeson >=1.2.1 && <1.6
-- containers >=0.3 && <0.7
-- filepath >=1.3 && <1.5
-- hashable >=1.2 && <1.4
-- lens >=4.1 && <4.20
-- mtl >=2.1 && <2.3
-- pretty >=1.1 && <1.3
-- process >=1.1 && <1.7
-- scientific >=0.3 && <0.5
-- text >=1.1 && <1.4
-- uniplate >=1.6 && <1.7
-- unordered-containers >=0.2 && <0.3
-- vector >=0.9 && <0.13
+- base >= 4.0.0 && < 5.0
+- GenericPretty
+- aeson
+- containers
+- filepath
+- hashable
+- lens
+- mtl
+- pretty
+- process
+- scientific
+- text
+- uniplate
+- unordered-containers
+- vector
 - json-alt
 - template-haskell
 library:
@@ -101,16 +101,16 @@ library:
   - Data.Aeson.AutoType.CodeGen.Generic
   - Data.Aeson.AutoType.CodeGen.Elm
   - Data.Aeson.AutoType.CodeGen.ElmFormat
-  - Data.Aeson.AutoType.Pretty
   - Data.Aeson.AutoType.Split
   - Data.Aeson.AutoType.Type
   - Data.Aeson.AutoType.Test
   - Data.Aeson.AutoType.Util
   - Data.Aeson.AutoType.Nested
+  - Data.Aeson.AutoType.Pretty
   dependencies:
-  - data-default >=0.7 && <0.8
-  - smallcheck >=1.0 && <1.2
-  - QuickCheck >=2.4 && <3.0
+  - data-default
+  - smallcheck
+  - QuickCheck
   - run-haskell-module
 executables:
   json-autotype:
@@ -119,9 +119,9 @@ executables:
     - app
     - common
     dependencies:
-    - bytestring >=0.9 && <0.11
-    - optparse-applicative >=0.12 && <1.0
-    - yaml >=0.8 && <0.12
+    - bytestring
+    - optparse-applicative
+    - yaml
     - json-autotype
 tests:
   json-autotype-examples:
@@ -130,10 +130,10 @@ tests:
     - test
     - common
     dependencies:
-    - directory >=1.1 && <1.4
-    - optparse-applicative >=0.11 && <1.0
-    - smallcheck >=1.0 && <1.2
-    - QuickCheck >=2.4 && <3.0
+    - directory
+    - optparse-applicative
+    - smallcheck
+    - QuickCheck
     - json-autotype
   json-autotype-qc-test:
     main: TestQC.hs
@@ -141,9 +141,9 @@ tests:
     - test/qc
     - common
     dependencies:
-    - smallcheck >=1.0 && <1.2
-    - optparse-applicative >=0.12 && <1.0
-    - QuickCheck >=2.4 && <3.0
+    - smallcheck
+    - optparse-applicative
+    - QuickCheck
     - json-autotype
   json-autotype-gen-test:
     main: GenerateTestJSON.hs
@@ -151,10 +151,10 @@ tests:
     - test/gen
     - common
     dependencies:
-    - bytestring >=0.9 && <0.11
-    - directory >=1.1 && <1.4
-    - optparse-applicative >=0.12 && <1.0
-    - smallcheck >=1.0 && <1.2
-    - QuickCheck >=2.4 && <3.0
+    - bytestring
+    - directory
+    - optparse-applicative
+    - smallcheck
+    - QuickCheck
     - json-autotype
 stability: stable

--- a/json-autotype/src/Data/Aeson/AutoType/Pretty.hs
+++ b/json-autotype/src/Data/Aeson/AutoType/Pretty.hs
@@ -13,6 +13,8 @@ module Data.Aeson.AutoType.Pretty() where
 import qualified Data.HashMap.Strict as Hash
 import           Data.HashMap.Strict(HashMap)
 import           Data.Aeson
+import qualified Data.Aeson.KeyMap          as KM
+import           Data.Aeson.AutoType.Type  (Dict(..), Type)
 import qualified Data.Text                  as Text
 import           Data.Text                 (Text)
 import           Data.Set                   as Set(Set, toList)
@@ -42,6 +44,18 @@ instance (Out a) => Out (Set a) where
 instance (Out a, Out b) => Out (HashMap a b) where
   doc (Hash.toList -> dict) = foldl ($$) "{" (map formatPair dict) $$ nest 1 "}"
   docPrec _ = doc
+
+instance (Out v) => Out (KM.KeyMap v) where
+  doc (KM.toList -> dict) = foldl ($$) "{" (map formatKeyValPair dict) $$ nest 1 "}"
+    where
+      formatKeyValPair (k, v) = nest 1 (doc (show k) <+> ": " <+> doc v <+> ",")
+  docPrec _ = doc
+
+instance Out Dict where
+  doc = doc . unDict
+
+instance Out Type where
+  doc = doc . show
 
 instance Out Text where
   doc       = text . Text.unpack -- TODO: check if there may be direct way?

--- a/json-autotype/src/Data/Aeson/AutoType/Test.hs
+++ b/json-autotype/src/Data/Aeson/AutoType/Test.hs
@@ -2,13 +2,13 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 -- | Arbitrary instances for the JSON @Value@.
 module Data.Aeson.AutoType.Test (
-    arbitraryTopValue
+  arbitraryTopValue
   ) where
-
-import           Data.Aeson.AutoType.Pretty          () -- Generic instance for Value
 
 import           Control.Applicative                 ((<$>), (<*>))
 import           Data.Aeson
+import           Data.Aeson.Key                      (fromText)
+import qualified Data.Aeson.KeyMap           as KM
 import           Data.Function                       (on)
 import           Data.Hashable                       (Hashable)
 import           Data.Generics.Uniplate.Data
@@ -45,48 +45,38 @@ makeMap  = Map.fromList
 instance Arbitrary Scientific where
   arbitrary = scientific <$> arbitrary <*> arbitrary
 
--- TODO: top value has to be complex: Object or Array
--- TODO: how to accumulate cost when generating the series?
-instance Arbitrary Value where
-  arbitrary = sized arb
-    where
-      arb n | n < 0 = error "Negative size!"
-      arb 0         = return Null
-      arb 1         = oneof                          simpleGens
-      arb i         = oneof $ complexGens (i - 1) ++ simpleGens
-      simpleGens    = [Number <$> arbitrary
-                      ,Bool   <$> arbitrary
-                      ,String <$> arbitrary]
-  shrink = concatMap simpleShrink
-         . universe
-
 -- | Transformation to shrink top level of @Value@, doesn't consider nested sub-@Value@s.
 simpleShrink           :: Value -> [Value]
-simpleShrink (Array  a) = map (Array  .   V.fromList) $ shrink $ V.toList   a
-simpleShrink (Object o) = map (Object . Map.fromList) $ shrink $ Map.toList o
+simpleShrink (Array  a) = map (Array  .  V.fromList) $ shrink $ V.toList  a
+simpleShrink (Object o) = map (Object . KM.fromList) $ shrink $ KM.toList o
 simpleShrink _          = [] -- Nothing for simple objects
 
 -- | Generator for compound @Value@s
 complexGens ::  Int -> [Gen Value]
-complexGens i = [Object . Map.fromList <$> resize i arbitrary,
-                 Array                 <$> resize i arbitrary]
+complexGens i = [Object . KM.fromList <$> resize i arbitrary,
+                 Array                <$> resize i arbitrary]
 
 -- | Arbitrary JSON (must start with Object or Array.)
 arbitraryTopValue :: Gen Value
 arbitraryTopValue  = sized $ oneof . complexGens
 
 -- * SmallCheck Serial instances
-instance Monad m => Serial m Text where
+instance (Monad m) => Serial m Text where
   series = newtypeCons Text.pack
 
-instance Monad m => Serial m Scientific where
+instance (Monad m) => Serial m Scientific where
   series = cons2 scientific
 
 instance Serial m a => Serial m (V.Vector a) where
   series = newtypeCons V.fromList
 
-instance Serial m v => Serial m (Map.HashMap Text v) where
-  series = newtypeCons makeMap
+instance (Monad m) => Serial m Key where
+  series = fmap fromText series
+
+instance Serial m v => Serial m (KM.KeyMap v) where
+  series = newtypeCons $ KM.fromList
+                       . nubBy  ((==) `on` fst)
+                       . sortBy (compare `on` fst)
 
 -- This one is generated with Generics and instances above
 instance Monad m => Serial m Value

--- a/json-autotype/src/Data/Aeson/AutoType/Type.hs
+++ b/json-autotype/src/Data/Aeson/AutoType/Type.hs
@@ -26,9 +26,7 @@ import           Data.HashMap.Strict(HashMap)
 import           Data.List          (sort)
 import           Data.Ord           (comparing)
 import           Data.Generics.Uniplate
-import           Text.PrettyPrint.GenericPretty
-
-import           Data.Aeson.AutoType.Pretty ()
+import           GHC.Generics      (Generic)
 
 -- * Dictionary types for overloading of usual class instances.
 -- | Type alias for HashMap
@@ -37,10 +35,6 @@ type Map = HashMap
 -- | Dictionary of types indexed by names.
 newtype Dict = Dict { unDict :: Map Text Type }
   deriving (Eq, Data, Typeable, Generic)
-
-instance Out Dict where
-  doc       = doc       . unDict
-  docPrec p = docPrec p . unDict
 
 instance Show Dict where
   show = show . sort . Hash.toList . unDict
@@ -64,8 +58,6 @@ data Type = TNull | TBool | TString        |
             TObj    Dict                   |
             TArray  Type
   deriving (Show,Eq, Ord, Data, Typeable, Generic)
-
-instance Out Type
 
 -- These are missing Uniplate instances...
 {-

--- a/json-autotype/src/Data/Aeson/AutoType/Util.hs
+++ b/json-autotype/src/Data/Aeson/AutoType/Util.hs
@@ -27,8 +27,3 @@ withFileOrDefaultHandle "-"      otherMode        _      = error $ "Incompatible
                                                                 ++ show otherMode
                                                                 ++ ") for `-` in withFileOrDefaultHandle."
 withFileOrDefaultHandle filename ioMode           action = withFile filename ioMode action
-
--- Missing instances
-instance Hashable a => Hashable (Set.Set a) where
-  hashWithSalt = Set.foldr (flip hashWithSalt)
-

--- a/json-autotype/test/TestExamples.hs
+++ b/json-autotype/test/TestExamples.hs
@@ -13,9 +13,10 @@ import System.Environment as Env
 import System.Process             (rawSystem)
 import Data.Aeson.AutoType.CodeGen(runModule, Lang(Haskell))
 import Data.Aeson ( Result,  Object, FromJSON, Value(Null,Number), (.:?) )
+import qualified Data.Aeson.KeyMap as KM
+import Data.Aeson.Key (fromString, fromText)
 import Data.Aeson.Types ( Parser, parse )
 import Data.Text ( Text, pack )
-import Data.HashMap.Lazy ( singleton, empty )
 
 
 -- |  <http://book.realworldhaskell.org/read/io-case-study-a-library-for-searching-the-filesystem.html>
@@ -82,16 +83,16 @@ runAutotype source arguments = do
 
 verifyAesonOperators :: IO ()
 verifyAesonOperators = do
-  parseTest (singleton (pack "foo") (Number 1))
-  parseTest (singleton (pack "foo")  Null     )
-  parseTest (singleton (pack "bar")  Null     )
-  parseTest empty
+  parseTest (KM.singleton (fromString "foo") (Number 1))
+  parseTest (KM.singleton (fromString "foo")  Null     )
+  parseTest (KM.singleton (fromString "bar")  Null     )
+  parseTest KM.empty
 
 (.:??) :: FromJSON a => Object -> Text -> Parser (Maybe a)
-o .:?? val = fmap join (o .:? val)
+o .:?? val = fmap join (o .:? fromText val)
 
 parseTest :: Object -> IO ()
 parseTest o = unless (r1 == r2) (fail (show r1 ++ " /= " ++ show r2))
   where r1, r2 :: Result (Maybe Int)
-        r1 = parse (.:? (pack "foo")) o
+        r1 = parse (.:? (fromString "foo")) o
         r2 = parse (.:?? (pack "foo")) o

--- a/json-autotype/test/gen/GenerateTestJSON.hs
+++ b/json-autotype/test/gen/GenerateTestJSON.hs
@@ -109,25 +109,6 @@ removeDuplicates list = filterM checkDup list `evalState` Set.empty
                         State.put $ x `Set.insert` seen
                         return True
 
--- TODO: check for generic Ord?
-instance Ord Value where
-  Null       `compare`  Null      = EQ
-  Null       `compare`  _         = LT
-  _          `compare`  Null      = GT
-  (Bool   a) `compare` (Bool   b) = a `compare` b
-  (Bool   a) `compare`  _         = LT
-  _          `compare` (Bool   b) = GT
-  (Number a) `compare` (Number b) = a `compare` b
-  (Number _) `compare`  _         = LT
-  _          `compare` (Number _) = GT
-  (String a) `compare` (String b) = a `compare` b
-  (String a) `compare` _          = LT
-  _          `compare` (String b) = GT
-  (Array  a) `compare` (Array  b) = a `compare` b
-  (Array  a) `compare` _          = LT
-  _          `compare` (Array  b) = GT
-  (Object a) `compare` (Object b) = Map.toList a `compare` Map.toList b
-
 -- | Take a set of JSON input filenames, Haskell output filename, and generate module parsing these JSON files.
 generateTestJSONs :: Options -> IO ()
 generateTestJSONs Options {tyOpts=TyOptions {..},

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.26
+resolver: lts-21.9
 
 packages:
 - json-autotype

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -7,13 +7,13 @@ packages:
 - completed:
     hackage: GenericPretty-1.2.2@sha256:65fd4aeedc326c356a866169e3511ef14fd6b3284ff9c29273f8a3b90dc9e5eb,3698
     pantry-tree:
-      size: 719
       sha256: 1e9f020c022023084c2a0e1650d21ea7cd87fe9a97a9f21c691b664d65142250
+      size: 719
   original:
     hackage: GenericPretty-1.2.2
 snapshots:
 - completed:
-    size: 509471
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/12/26.yaml
-    sha256: 95f014df58d0679b1c4a2b7bf2b652b61da8d30de5f571abb0d59015ef678646
-  original: lts-12.26
+    sha256: 2fc12a405ab6f7eac73eb11a0ca5ccca0e956bd2848db780c140b7406ff9ebb5
+    size: 640035
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/9.yaml
+  original: lts-21.9


### PR DESCRIPTION
This pull request updates the package to work with the latest Stack LTS resolver.

This change has three main components:

- update `stack.yaml` to specify the LTS 21.9 resolver and eliminate explicit version bounds on most dependencies;
- delete several orphan instances that are redundant of instances exported by newer dependencies; and
- update the codebase for compatibility with Aeson's `KeyMap` type (introduced in v2.0.0.0).

The package builds successfully with `stack build`.

There are a few outstanding issues:

 - The `json-autotype-gen-test` test suite fails. I suspect this was already the case, but I don't know because I can't get the package to build without my updates. The test suit is opaque, so I can't see why it's failing.
- The package does not build with `cabal build`, failing immediately with a parse error of the `cabal.project` file. I didn't look into this, but I suggest deleting all of the Cabal-specific files and (if desired) re-generating them from the working Stack config with a tool like `stack2cabal`.
- Hpack decremented the version number of the `json-alt` package in its `json-alt.cabal` file from 1.0.1 to 1.0.0., presumably because someone in the past edited the Cabal file directly rather than the Hpack `package.yaml` file to bump the version number. Hpack doesn't offer much at this point aside from incidental complexity, so I would suggest again generating Cabal files from the working Stack config, and getting rid of the Hpack config files altogether.
- I didn't bump the version numbers on any of the packages.

If you interested in merging this, let me know what you'd like done to get it in a state you'd be happy with.